### PR TITLE
Replace fatalError with graceful error handling

### DIFF
--- a/Steady/MetronomeViewModel.swift
+++ b/Steady/MetronomeViewModel.swift
@@ -147,11 +147,15 @@ class MetronomeViewModel: ObservableObject {
 #endif
         
         guard let clickUrl = Bundle.main.url(forResource: "click_low", withExtension: "wav") else {
-            fatalError("click sound not found.")
+            print("Warning: click_low.wav sound file not found. Audio will be disabled.")
+            soundEnabled = false
+            return
         }
         
         guard let accentUrl = Bundle.main.url(forResource: "click_high", withExtension: "wav") else {
-            fatalError("accent sound not found.")
+            print("Warning: click_high.wav sound file not found. Audio will be disabled.")
+            soundEnabled = false
+            return
         }
         
         do {
@@ -161,7 +165,10 @@ class MetronomeViewModel: ObservableObject {
             accentAudioPlayer = try AVAudioPlayer(contentsOf: accentUrl)
             accentAudioPlayer?.prepareToPlay()
         } catch {
-            fatalError("unable to load click sound: \(error)")
+            print("Warning: unable to load click sounds: \(error). Audio will be disabled.")
+            soundEnabled = false
+            clickAudioPlayer = nil
+            accentAudioPlayer = nil
         }
     }
     


### PR DESCRIPTION
## Summary
• Replace fatalError calls with graceful degradation when audio files are missing
• Disable audio functionality instead of crashing the app
• Provide user-friendly warning messages in console

## Test plan
- [ ] Test app startup with missing audio files
- [ ] Verify metronome continues to work without audio when files are missing
- [ ] Confirm app doesn't crash on audio loading errors
- [ ] Test normal operation with audio files present

🤖 Generated with [Claude Code](https://claude.ai/code)