### PR TITLE
Fix accessibility identifier typo

### DIFF
--- a/Steady/ContentView.swift
+++ b/Steady/ContentView.swift
@@ -208,7 +208,7 @@ struct ContentView: View {
                     Image(systemName: "1.square")
                         .accessibilityHidden(true)
                     Toggle("Accent first beat", isOn: $model.accentFirstBeatEnabled)
-                        .accessibilityIdentifier("accessFirstBeatEnabledToggle")
+                        .accessibilityIdentifier("accentFirstBeatEnabledToggle")
                         .accessibilityHint("Play a different sound for the first beat of a measure")
                 }
                 


### PR DESCRIPTION
## Summary
• Correct accessibility identifier from "accessFirstBeatEnabledToggle" to "accentFirstBeatEnabledToggle"
• Ensure consistency between UI element purpose and identifier naming

## Test plan
- [ ] Verify accessibility identifier is correctly named
- [ ] Test accessibility functionality with VoiceOver
- [ ] Confirm UI tests can locate the toggle correctly

🤖 Generated with [Claude Code](https://claude.ai/code)